### PR TITLE
Project build, test and publish setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Build and test kotask
+
+on:
+  pull_request:
+    branches: [ "*" ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '18'
+        distribution: 'corretto'
+    - name: Start containers for tests
+      run: docker compose -f ./docker-compose.yaml up -d --force-recreate
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@v2.4.0
+      with:
+        arguments: build
+    - name: Stop containers for tests
+      run: docker compose -f ./docker-compose.yaml down 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Publish Kotask to maven
+
+on:
+  release:
+    branches: [ "*" ]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps: # TODO: reuse build workflow job
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '18'
+        distribution: 'corretto'
+    - name: Start containers for tests
+      run: docker compose -f ./docker-compose.yaml up -d --force-recreate
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@v2.4.0
+      with:
+        arguments: build
+    - name: Stop containers for tests
+      run: docker compose -f ./docker-compose.yaml down 
+    - name: Publish package
+      uses: gradle/gradle-build-action@v2.4.0
+      with:
+        arguments: publish
+      env:
+        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_PUBLISHING_SECRET_KEY }}
+        ORG_GRADLE_PROJECT_signingPassword:  ${{ secrets.MAVEN_PUBLISHING_PASSPHRASE }}
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD:  ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea
 *.iml
+.dccache
 
 # Compiled class file
 *.class

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Ilya Tikhonov (https://github.com/ilyatikhonov)
+Copyright (c) 2023 Zamna (https://github.com/vchain-dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023 Ilya Tikhonov (https://github.com/ilyatikhonov)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,10 @@ publishing {
                         id.set("ilyatikhonov")
                         name.set("Ilya Tikhonov")
                     }
+                    developer {
+                        id.set("baitcode")
+                        name.set("Ilia Batii")
+                    }
                 }
             }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,30 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-
 plugins {
     kotlin("jvm") version "1.7.20"
     kotlin("plugin.serialization") version "1.7.20"
-    `maven-publish`
+
+    id("java-library")
+    id("maven-publish")
+    id("signing")
+    id("org.jetbrains.dokka") version "1.8.10"
 }
 
 group = "com.zamna"
-version = "0.5"
+version = "0.5.1"
+description = "Kotlin asynchronous task framework using RabbitMQ."
+
+val kotestVersion = "5.5.4"
+val exposedVersion: String = "0.41.1"
 
 repositories {
     mavenCentral()
 }
 
-val exposedVersion: String = "0.41.1"
+tasks.jar {
+    manifest {
+        attributes(mapOf("Implementation-Title" to project.name,
+            "Implementation-Version" to project.version))
+    }
+}
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
@@ -42,24 +52,102 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-json:5.5.5")
     testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:1.3.4")
     testImplementation("org.testcontainers:postgresql:1.18.3")
-    
+
 }
 
 tasks.test {
     useJUnitPlatform()
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+tasks.publishToMavenLocal {
+    dependsOn(tasks.jar)
+}
+
+tasks.publish {
+    dependsOn(tasks.jar)
+}
+
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    dependsOn(tasks.classes)
+
+    from(sourceSets["main"].allSource)
+    archiveClassifier.set("sources")
+}
+
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+    dependsOn(tasks.dokkaJavadoc)
+    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+    archiveClassifier.set("javadoc")
+}
+
+tasks.jar {
+    dependsOn(dokkaJavadocJar)
+    dependsOn(sourcesJar)
 }
 
 publishing {
+
+    repositories {
+        maven {
+            name = "SonatypeMavenCentral"
+            url = uri("https://s01.oss.sonatype.org/content/repositories/releases")
+            credentials {
+                username = System.getenv("MAVEN_CENTRAL_USERNAME")
+                password = System.getenv("MAVEN_CENTRAL_PASSWORD")
+            }
+        }
+    }
+
     publications {
         create<MavenPublication>("kotask") {
             groupId = "com.zamna"
-            artifactId = "kotask"
-            version = "0.5"
-            from(components["java"])
+            artifactId = project.name as String
+            version = project.version as String
+
+            from(components["kotlin"])
+
+            artifact(dokkaJavadocJar)
+            artifact(sourcesJar)
+
+            pom {
+                packaging = "jar"
+
+                name.set(project.name as String)
+                description.set(project.description as String)
+
+                url.set("https://github.com/vchain-dev/kotask")
+
+                scm {
+                    url.set("https://github.com/vchain-dev/kotask")
+                }
+
+                issueManagement {
+                    url.set("https://github.com/vchain-dev/kotask/issues")
+                }
+
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://github.com/vchain-dev/kotask/blob/main/LICENSE")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("ilyatikhonov")
+                        name.set("Ilya Tikhonov")
+                    }
+                }
+            }
+
         }
     }
+}
+
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+
+    sign(publishing.publications["kotask"])
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,1 @@
-
 rootProject.name = "kotask"
-

--- a/src/main/kotlin/RetryPolicy.kt
+++ b/src/main/kotlin/RetryPolicy.kt
@@ -46,6 +46,13 @@ class ForceRetry(val delay: Duration): RetryControlException() {
     )
 }
 
+/**
+ * An exception that indicates that task should be retried after delay.
+ *
+ *
+ * @param delay Delay duration after which task should be retried.
+ * @constructor Creates RetryControlException instance.
+ */
 class RepeatTask(val delay: Duration): RetryControlException() {
     fun getRetryCallParams(params: CallParams) = params.copy(
         delay = delay,


### PR DESCRIPTION
Maven publication setup

Every time you create release on github library is being sent to sonatipe repo and published to maven central (lag is about 30 minutes). It's only possible to upload release once. So no hotfixes.
Library is being published along with javadoc documentation and sources. Javadoc is being generated by KDok