### PR TITLE
Fix start workers problem

### DIFF
--- a/src/main/kotlin/Task.kt
+++ b/src/main/kotlin/Task.kt
@@ -1,5 +1,6 @@
 package com.zamna.kotask
 
+import com.zamna.kotask.execptions.TaskAlreadyRegistered
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -34,7 +35,13 @@ class TaskRegistry internal constructor() {
     companion object {
         fun get(taskName: String): Task<*> = instance.tasks[taskName]!!
 
+        fun clean() { instance.tasks.clear() }
+
         fun register(task: Task<*>) {
+            if (task.name in instance.tasks) {
+                throw TaskAlreadyRegistered("")
+            }
+
             instance.tasks.getOrPut(task.name) { task }
         }
 

--- a/src/main/kotlin/Task.kt
+++ b/src/main/kotlin/Task.kt
@@ -17,13 +17,13 @@ class TaskCallFactory<T: Any>(val task: Task<T>, val input: T, val manager: Task
 object NoInput
 
 object TaskEvents {
-    val MESSAGE_RECEIVED: String = "MESSAGE_RECEIVED"
-    val MESSAGE_SENT: String = "MESSAGE_SENT"
-    val MESSAGE_SUBMIT_RETRY: String = "MESSAGE_SUBMIT_RETRY"
-    val MESSAGE_FAIL: String = "MESSAGE_FAIL"
-    val MESSAGE_FAIL_RETRY: String = "MESSAGE_FAIL_RETRY"
-    val MESSAGE_FAIL_NO_RETRY: String = "MESSAGE_FAIL_NO_RETRY"
-    val MESSAGE_COMPLETE: String = "MESSAGE_COMPLETE"
+    const val MESSAGE_RECEIVED: String = "MESSAGE_RECEIVED"
+    const val MESSAGE_SENT: String = "MESSAGE_SENT"
+    const val MESSAGE_SUBMIT_RETRY: String = "MESSAGE_SUBMIT_RETRY"
+    const val MESSAGE_FAIL: String = "MESSAGE_FAIL"
+    const val MESSAGE_FAIL_RETRY: String = "MESSAGE_FAIL_RETRY"
+    const val MESSAGE_FAIL_NO_RETRY: String = "MESSAGE_FAIL_NO_RETRY"
+    const val MESSAGE_COMPLETE: String = "MESSAGE_COMPLETE"
 }
 
 class TaskRegistry internal constructor() {

--- a/src/main/kotlin/Task.kt
+++ b/src/main/kotlin/Task.kt
@@ -32,7 +32,7 @@ class TaskRegistry internal constructor() {
 
 
     companion object {
-        fun get(taskName: String): Task<*>  = instance.tasks[taskName]!!
+        fun get(taskName: String): Task<*> = instance.tasks[taskName]!!
 
         fun register(task: Task<*>) {
             instance.tasks.getOrPut(task.name) { task }

--- a/src/main/kotlin/com/zamna/kotask/execptions/TaskAlreadyRegistered.kt
+++ b/src/main/kotlin/com/zamna/kotask/execptions/TaskAlreadyRegistered.kt
@@ -1,0 +1,5 @@
+package com.zamna.kotask.execptions
+
+class TaskAlreadyRegistered(taskName: String) : Throwable() {
+    override val message: String = "Task $taskName is already registered."
+}

--- a/src/test/kotlin/TaskManagerTest.kt
+++ b/src/test/kotlin/TaskManagerTest.kt
@@ -10,6 +10,7 @@ import io.kotest.extensions.testcontainers.TestContainerExtension
 import io.kotest.framework.concurrency.continually
 import io.kotest.framework.concurrency.eventually
 import io.kotest.framework.concurrency.until
+import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
@@ -106,6 +107,16 @@ fun taskManagerTest(taskManager: TaskManager) = funSpec {
         taskManager.startWorkers(testTask1, testTask2, testFailingTask, testFailingOnceTask)
     }
 
+    test("TaskManager should have 4 consumers registered") {
+        taskManager.tasksConsumers.keys shouldBe setOf(
+            testTask1.name,
+            testTask2.name,
+            testFailingOnceTask.name,
+            testFailingTask.name,
+            cleanScheduleWorker.name,
+        )
+    }
+
     // Tests
     test("test basic queues, execution, delays") {
 
@@ -128,9 +139,6 @@ fun taskManagerTest(taskManager: TaskManager) = funSpec {
                 it.isExecuted() shouldBe true
             }
         }
-
-
-
     }
 
     test("TaskCall isExecuted updates after call") {

--- a/src/test/kotlin/scheduling/manager_scheduling_specs.kt
+++ b/src/test/kotlin/scheduling/manager_scheduling_specs.kt
@@ -1,6 +1,7 @@
 import com.zamna.kotask.IRepeatingSchedulePolicy
 import com.zamna.kotask.Task
 import com.zamna.kotask.TaskManager
+import com.zamna.kotask.TaskRegistry
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.funSpec
@@ -14,6 +15,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalKotest::class)
 fun taskManagerSchedulingTest(taskManager: TaskManager) = funSpec {
+    TaskRegistry.clean()
     Settings.scheduleDelayDuration = 1.seconds
 
     class RepeatingScheduleTestTaskPolicy(


### PR DESCRIPTION
removed duplicate task definition checks from TaskManager and introduced those checks on Task.create.
All tasks are now registred in TaskRegistry and startWorker
```kotlin

    fun enqueueTaskCall(call: TaskCall) {
        withLogCtx(
            "callId" to (call.message.headers["call-id"] ?: "unknown"),
            "taskName" to call.taskName,
            "delayMs" to call.message.delayMs.toString()
        ) {
            logger.debug { "Enqueue task call" }
            broker.submitMessage(queueNameByTaskName(call.taskName), call.message)
            if (broker is LocalBroker) startWorker(TaskRegistry.get(call.taskName))
        }
    }

```

Local broker now starts task on enqeue using TaskRegistry

Now only one consumer per task is allowed